### PR TITLE
Add optional AWS benchmark metrics collection

### DIFF
--- a/src/snakemake/benchmark.py
+++ b/src/snakemake/benchmark.py
@@ -5,11 +5,20 @@ __license__ = "MIT"
 
 import contextlib
 import datetime
+import io
+import json
 from itertools import chain
 import os
+import shutil
+import socket
+import subprocess
 import time
 import threading
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 from snakemake.logging import logger
 
@@ -19,12 +28,209 @@ BENCHMARK_INTERVAL = 30
 #: BENCHMARK_INTERVAL
 BENCHMARK_INTERVAL_SHORT = 0.5
 
+#: Base URL for AWS metadata service queries
+AWS_METADATA_BASE_URL = "http://169.254.169.254/latest"
+#: Timeout in seconds when querying AWS metadata service
+AWS_METADATA_TIMEOUT = 1
+#: Timeout in seconds when invoking the AWS CLI for spot pricing
+AWS_CLI_TIMEOUT = 10
+
+
+class AwsMetricsError(Exception):
+    """Raised when AWS specific benchmark metrics cannot be collected."""
+
+
+@dataclass
+class AwsSystemMetrics:
+    hostname: str
+    ip: str
+    nproc: Optional[int]
+    instance_type: str
+    region_az: str
+    spot_cost: Optional[str]
+
+
+def _get_metadata_token() -> Optional[str]:
+    request = Request(
+        f"{AWS_METADATA_BASE_URL}/api/token",
+        method="PUT",
+        headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+    )
+    try:
+        with urlopen(request, timeout=AWS_METADATA_TIMEOUT) as response:
+            token = response.read().decode()
+            return token or None
+    except Exception as err:  # noqa: BLE001
+        logger.debug("Unable to obtain AWS metadata token: %s", err)
+        return None
+
+
+def _metadata_request(path: str, token: Optional[str], required: bool = True) -> Optional[str]:
+    url = f"{AWS_METADATA_BASE_URL}/{path}"
+    request = Request(url)
+    if token:
+        request.add_header("X-aws-ec2-metadata-token", token)
+    try:
+        with urlopen(request, timeout=AWS_METADATA_TIMEOUT) as response:
+            return response.read().decode()
+    except HTTPError as err:
+        if err.code == 404 and not required:
+            return None
+        raise AwsMetricsError(f"metadata query {path} failed with HTTP {err.code}") from err
+    except URLError as err:
+        raise AwsMetricsError(f"cannot reach AWS metadata service for {path}: {err}") from err
+
+
+def _fallback_ip(hostname: Optional[str]) -> Optional[str]:
+    if not hostname:
+        return None
+    try:
+        return socket.gethostbyname(hostname)
+    except OSError:
+        return None
+
+
+def _try_boto3_spot_price(
+    instance_type: str, region: Optional[str], availability_zone: Optional[str]
+):
+    try:
+        import boto3  # type: ignore
+    except ImportError as err:
+        return False, f"boto3 is not installed: {err}"
+
+    try:
+        client_kwargs = {}
+        if region:
+            client_kwargs["region_name"] = region
+        ec2_client = boto3.client("ec2", **client_kwargs)
+        request_kwargs = {
+            "InstanceTypes": [instance_type],
+            "ProductDescriptions": ["Linux/UNIX"],
+            "MaxResults": 1,
+        }
+        if availability_zone:
+            request_kwargs["AvailabilityZone"] = availability_zone
+        response = ec2_client.describe_spot_price_history(**request_kwargs)
+        history = response.get("SpotPriceHistory") or []
+        if history:
+            return True, history[0].get("SpotPrice")
+        return True, None
+    except Exception as err:  # noqa: BLE001
+        return False, f"boto3 error: {err}"
+
+
+def _try_aws_cli_spot_price(
+    instance_type: str, region: Optional[str], availability_zone: Optional[str]
+):
+    aws_cli = shutil.which("aws")
+    if not aws_cli:
+        return False, "aws executable not found"
+
+    cmd = [
+        aws_cli,
+        "ec2",
+        "describe-spot-price-history",
+        "--instance-types",
+        instance_type,
+        "--product-descriptions",
+        "Linux/UNIX",
+        "--max-results",
+        "1",
+    ]
+    if availability_zone:
+        cmd.extend(["--availability-zone", availability_zone])
+
+    env = os.environ.copy()
+    if region:
+        env.setdefault("AWS_DEFAULT_REGION", region)
+
+    try:
+        result = subprocess.run(  # noqa: S603
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=AWS_CLI_TIMEOUT,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as err:
+        return False, f"AWS CLI timed out: {err}"
+    except subprocess.CalledProcessError as err:
+        stderr = (err.stderr or "").strip()
+        return False, f"AWS CLI returned non-zero exit status {err.returncode}: {stderr}"
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as err:
+        return False, f"failed to parse AWS CLI output: {err}"
+
+    history = payload.get("SpotPriceHistory") or []
+    if history:
+        return True, history[0].get("SpotPrice")
+    return True, None
+
+
+def _get_spot_price(instance_type: str, region_az: str) -> Optional[str]:
+    region = region_az[:-1] if region_az else None
+    boto_success, boto_result = _try_boto3_spot_price(instance_type, region, region_az)
+    if boto_success:
+        return boto_result
+
+    cli_success, cli_result = _try_aws_cli_spot_price(instance_type, region, region_az)
+    if cli_success:
+        return cli_result
+
+    errors = []
+    if boto_result:
+        errors.append(str(boto_result))
+    if cli_result:
+        errors.append(str(cli_result))
+    message = "; ".join(errors) if errors else "unable to retrieve spot price"
+    raise AwsMetricsError(message)
+
+
+def collect_aws_benchmark_metrics() -> AwsSystemMetrics:
+    hostname = None
+    try:
+        hostname = socket.gethostname()
+    except OSError as err:
+        logger.debug("Unable to determine hostname: %s", err)
+
+    token = _get_metadata_token()
+    instance_type = _metadata_request("meta-data/instance-type", token)
+    region_az = _metadata_request("meta-data/placement/availability-zone", token)
+
+    ip = None
+    try:
+        ip = _metadata_request("meta-data/public-ipv4", token, required=False)
+    except AwsMetricsError as err:
+        logger.debug("Public IPv4 metadata unavailable: %s", err)
+    if not ip:
+        try:
+            ip = _metadata_request("meta-data/local-ipv4", token, required=False)
+        except AwsMetricsError as err:
+            logger.debug("Local IPv4 metadata unavailable: %s", err)
+    if not ip:
+        ip = _fallback_ip(hostname)
+
+    nproc = os.cpu_count()
+    spot_cost = _get_spot_price(instance_type, region_az)
+
+    return AwsSystemMetrics(
+        hostname=hostname or "NA",
+        ip=ip or "NA",
+        nproc=nproc,
+        instance_type=instance_type or "NA",
+        region_az=region_az or "NA",
+        spot_cost=spot_cost,
+    )
+
 
 class BenchmarkRecord:
     """Record type for benchmark times"""
 
     @classmethod
-    def get_header(klass, extended_fmt=False):
+    def get_header(klass, extended_fmt=False, include_aws_metrics: bool = False):
         header = [
             "s",
             "h:m:s",
@@ -48,6 +254,19 @@ class BenchmarkRecord:
                 "cpu_usage",
                 "resources",
                 "input_size_mb",
+            ]
+
+        if include_aws_metrics:
+            header += [
+                "hostname",
+                "ip",
+                "nproc",
+                "cpu_efficiency",
+                "instance_type",
+                "region_az",
+                "spot_cost",
+                "snakemake_threads",
+                "task_cost",
             ]
 
         return header
@@ -142,9 +361,90 @@ class BenchmarkRecord:
     def input_size_mb(self):
         return {file: Path(file).stat().st_size / 1024 / 1024 for file in self.input}
 
-    def get_benchmarks(self, extended_fmt=False):
+    def _threads_numeric_and_display(self):
+        threads = self.threads
+        if isinstance(threads, tuple):
+            threads = threads[0] if threads else None
+        if threads is None:
+            return None, "NA"
+        display = str(threads)
+        numeric = None
+        try:
+            numeric = float(threads)
+        except (TypeError, ValueError):
+            try:
+                numeric = float(display)
+            except (TypeError, ValueError):
+                numeric = None
+        return numeric, display
+
+    def _aws_metrics(self):
+        metrics = collect_aws_benchmark_metrics()
+
+        nproc_value = metrics.nproc
+        nproc_str = str(nproc_value) if nproc_value is not None else "NA"
+
+        cpu_efficiency = "NA"
+        if (
+            self.data_collected
+            and self.running_time
+            and self.running_time > 0
+            and self.cpu_time is not None
+        ):
+            try:
+                cpu_efficiency = f"{self.cpu_time / self.running_time:.4f}"
+            except ZeroDivisionError:
+                cpu_efficiency = "NA"
+
+        threads_numeric, threads_display = self._threads_numeric_and_display()
+
+        spot_cost_display = "NA"
+        spot_cost_numeric = None
+        if metrics.spot_cost not in (None, ""):
+            try:
+                spot_cost_numeric = float(metrics.spot_cost)
+                spot_cost_display = f"{spot_cost_numeric:.6f}"
+            except (TypeError, ValueError):
+                spot_cost_display = str(metrics.spot_cost)
+                try:
+                    spot_cost_numeric = float(spot_cost_display)
+                except (TypeError, ValueError):
+                    spot_cost_numeric = None
+
+        task_cost = "NA"
+        if (
+            spot_cost_numeric is not None
+            and self.running_time
+            and self.running_time > 0
+            and threads_numeric not in (None, 0)
+            and nproc_value not in (None, 0)
+        ):
+            try:
+                runtime_hours = self.running_time / 3600.0
+                task_cost = (
+                    f"{(threads_numeric / float(nproc_value)) * (spot_cost_numeric * runtime_hours):.6f}"
+                )
+            except (TypeError, ValueError, ZeroDivisionError):
+                task_cost = "NA"
+
+        return [
+            metrics.hostname or "NA",
+            metrics.ip or "NA",
+            nproc_str,
+            cpu_efficiency,
+            metrics.instance_type or "NA",
+            metrics.region_az or "NA",
+            spot_cost_display,
+            threads_display,
+            task_cost,
+        ]
+
+    def get_benchmarks(
+        self, extended_fmt=False, include_aws_metrics: bool = False
+    ):
         logger.debug(
-            f"Stats included in benchmarks file: {self.get_header(extended_fmt)}"
+            "Stats included in benchmarks file: %s",
+            self.get_header(extended_fmt, include_aws_metrics),
         )
         if self.skipped_procs:
             logger.debug(
@@ -195,9 +495,11 @@ class BenchmarkRecord:
                 self.parse_resources(),
                 self.input_size_mb(),
             ]
+        if include_aws_metrics:
+            record += self._aws_metrics()
         return record
 
-    def to_tsv(self, extended_fmt):
+    def to_tsv(self, extended_fmt, include_aws_metrics: bool = False):
         """Return ``str`` with the TSV representation of this record"""
 
         def to_tsv_str(x):
@@ -209,14 +511,23 @@ class BenchmarkRecord:
             else:
                 return str(x)
 
-        return "\t".join(map(to_tsv_str, self.get_benchmarks(extended_fmt)))
+        return "\t".join(
+            map(
+                to_tsv_str,
+                self.get_benchmarks(extended_fmt, include_aws_metrics),
+            )
+        )
 
-    def to_json(self, extended_fmt):
+    def to_json(self, extended_fmt, include_aws_metrics: bool = False):
         """Return ``str`` with the JSON representation of this record"""
-        import json
 
         return json.dumps(
-            dict(zip(self.get_header(extended_fmt), self.get_benchmarks(extended_fmt))),
+            dict(
+                zip(
+                    self.get_header(extended_fmt, include_aws_metrics),
+                    self.get_benchmarks(extended_fmt, include_aws_metrics),
+                )
+            ),
             sort_keys=True,
         )
 
@@ -432,25 +743,53 @@ def benchmarked(pid=None, benchmark_record=None, interval=BENCHMARK_INTERVAL):
         result.running_time = time.time() - start_time
 
 
-def print_benchmark_tsv(records, file_, extended_fmt):
+def print_benchmark_tsv(records, file_, extended_fmt, include_aws_metrics):
     """Write benchmark records to file-like the object"""
     logger.debug("Benchmarks in TSV format")
-    print("\t".join(BenchmarkRecord.get_header(extended_fmt)), file=file_)
+    print(
+        "\t".join(BenchmarkRecord.get_header(extended_fmt, include_aws_metrics)),
+        file=file_,
+    )
     for r in records:
-        print(r.to_tsv(extended_fmt), file=file_)
+        print(r.to_tsv(extended_fmt, include_aws_metrics), file=file_)
 
 
-def print_benchmark_jsonl(records, file_, extended_fmt):
+def print_benchmark_jsonl(records, file_, extended_fmt, include_aws_metrics):
     """Write benchmark records to file-like the object"""
     logger.debug("Benchmarks in JSONL format")
     for r in records:
-        print(r.to_json(extended_fmt), file=file_)
+        print(r.to_json(extended_fmt, include_aws_metrics), file=file_)
 
 
-def write_benchmark_records(records, path, extended_fmt):
+def _render_benchmark_records(
+    records, extended_fmt, include_aws_metrics, json_lines: bool
+):
+    buffer = io.StringIO()
+    if json_lines:
+        print_benchmark_jsonl(records, buffer, extended_fmt, include_aws_metrics)
+    else:
+        print_benchmark_tsv(records, buffer, extended_fmt, include_aws_metrics)
+    return buffer.getvalue()
+
+
+def write_benchmark_records(
+    records, path, extended_fmt, include_aws_metrics: bool = False
+):
     """Write benchmark records to file at path"""
-    with open(path, "wt") as f:
-        if path.endswith(".jsonl"):
-            print_benchmark_jsonl(records, f, extended_fmt)
+    json_lines = path.endswith(".jsonl")
+    try:
+        output = _render_benchmark_records(
+            records, extended_fmt, include_aws_metrics, json_lines
+        )
+    except AwsMetricsError as err:
+        if include_aws_metrics:
+            logger.error(
+                "Falling back to standard benchmark output because AWS metrics could not be collected: %s",
+                err,
+            )
+            output = _render_benchmark_records(records, extended_fmt, False, json_lines)
         else:
-            print_benchmark_tsv(records, f, extended_fmt)
+            raise
+
+    with open(path, "wt") as f:
+        f.write(output)

--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -1560,6 +1560,12 @@ def get_argument_parser(profiles=None):
         action="store_true",
         help="Write extended benchmarking metrics.",
     )
+    group_behavior.add_argument(
+        "--include-aws-benchmark-metrics",
+        default=False,
+        action="store_true",
+        help="Augment benchmark files with AWS-specific metrics when running on AWS EC2.",
+    )
 
     group_cluster = parser.add_argument_group("REMOTE EXECUTION")
 
@@ -1918,6 +1924,7 @@ def create_output_settings(args, log_handler_settings) -> OutputSettings:
         keep_logger=False,
         stdout=args.dryrun,
         benchmark_extended=args.benchmark_extended,
+        include_aws_benchmark_metrics=args.include_aws_benchmark_metrics,
     )
 
     # Set logging behavior based on execution mode

--- a/src/snakemake/executors/local.py
+++ b/src/snakemake/executors/local.py
@@ -478,6 +478,11 @@ def run_wrapper(
                 bench_record.resources = resources
                 bench_record.input = input
                 bench_record.threads = threads
-            write_benchmark_records(bench_records, benchmark, benchmark_extended)
+            write_benchmark_records(
+                bench_records,
+                benchmark,
+                benchmark_extended,
+                self.workflow.output_settings.include_aws_benchmark_metrics,
+            )
         except Exception as ex:
             raise WorkflowError(ex)

--- a/src/snakemake/settings/types.py
+++ b/src/snakemake/settings/types.py
@@ -406,6 +406,7 @@ class OutputSettings(SettingsBase, OutputSettingsLoggerInterface):
     keep_logger: bool = False
     stdout: bool = False
     benchmark_extended: bool = False
+    include_aws_benchmark_metrics: bool = False
     log_level_override: Optional[int] = (
         None  # Override log level (e.g., ERROR for subprocess)
     )

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -336,6 +336,7 @@ class SpawnedJobArgsFactory:
             w2a("config_settings.config_args", flag="--config"),
             w2a("output_settings.printshellcmds"),
             w2a("output_settings.benchmark_extended"),
+            w2a("output_settings.include_aws_benchmark_metrics"),
             w2a("execution_settings.latency_wait"),
             w2a("scheduling_settings.scheduler", flag="--scheduler"),
             w2a("workflow_settings.cache"),

--- a/tests/test_benchmark_aws.py
+++ b/tests/test_benchmark_aws.py
@@ -1,0 +1,97 @@
+from snakemake.benchmark import (
+    AwsMetricsError,
+    AwsSystemMetrics,
+    BenchmarkRecord,
+    write_benchmark_records,
+)
+
+
+def _build_record():
+    record = BenchmarkRecord(
+        running_time=60,
+        max_rss=1,
+        max_vms=1,
+        max_uss=1,
+        max_pss=1,
+        io_in=1,
+        io_out=1,
+        cpu_usage=120,
+        cpu_time=90,
+        threads=4,
+        input=[],
+    )
+    record.data_collected = True
+    return record
+
+
+def test_header_includes_aws_columns():
+    header = BenchmarkRecord.get_header(include_aws_metrics=True)
+    assert header[:10] == [
+        "s",
+        "h:m:s",
+        "max_rss",
+        "max_vms",
+        "max_uss",
+        "max_pss",
+        "io_in",
+        "io_out",
+        "mean_load",
+        "cpu_time",
+    ]
+    assert header[-9:] == [
+        "hostname",
+        "ip",
+        "nproc",
+        "cpu_efficiency",
+        "instance_type",
+        "region_az",
+        "spot_cost",
+        "snakemake_threads",
+        "task_cost",
+    ]
+
+
+def test_write_benchmark_records_with_aws_metrics(tmp_path, monkeypatch):
+    record = _build_record()
+
+    def fake_collect():
+        return AwsSystemMetrics(
+            hostname="test-host",
+            ip="1.2.3.4",
+            nproc=8,
+            instance_type="m5.large",
+            region_az="us-east-1a",
+            spot_cost="0.1",
+        )
+
+    monkeypatch.setattr(
+        "snakemake.benchmark.collect_aws_benchmark_metrics", fake_collect
+    )
+
+    path = tmp_path / "bench.tsv"
+    write_benchmark_records([record], str(path), extended_fmt=False, include_aws_metrics=True)
+
+    lines = path.read_text().strip().splitlines()
+    assert "hostname" in lines[0]
+    assert "test-host" in lines[1]
+    assert "0.100000" in lines[1]
+    assert "1.5000" in lines[1]  # cpu_efficiency
+    assert "0.000833" in lines[1]  # task_cost
+
+
+def test_write_benchmark_records_fallback(tmp_path, monkeypatch, caplog):
+    record = _build_record()
+
+    def fail_collect():
+        raise AwsMetricsError("no metadata")
+
+    monkeypatch.setattr(
+        "snakemake.benchmark.collect_aws_benchmark_metrics", fail_collect
+    )
+
+    path = tmp_path / "bench.tsv"
+    write_benchmark_records([record], str(path), extended_fmt=False, include_aws_metrics=True)
+
+    lines = path.read_text().strip().splitlines()
+    assert "hostname" not in lines[0]
+    assert any("AWS metrics could not be collected" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- add an `--include-aws-benchmark-metrics` CLI flag and plumb it through workflow settings and executors
- extend benchmark writing to collect AWS host metadata and spot pricing when requested, falling back to the legacy format if collection fails
- add unit coverage for the new header, AWS metrics output, and fallback behaviour

## Testing
- PYTHONPATH=src python -c "import types, sys, pytest; mod = types.ModuleType('snakemake._version'); mod.version='0.0.0'; sys.modules['snakemake._version']=mod; raise SystemExit(pytest.main(['tests/test_benchmark_aws.py']))"

------
https://chatgpt.com/codex/tasks/task_e_68d0621b9ed88331b84d47456f6e6cf3