### PR TITLE
Fix local executor AWS benchmark flag

### DIFF
--- a/src/snakemake/executors/local.py
+++ b/src/snakemake/executors/local.py
@@ -170,6 +170,7 @@ class Executor(RealExecutor):
             job.rule.basedir,
             self.workflow.sourcecache.cache_path,
             self.workflow.sourcecache.runtime_cache_path,
+            self.workflow.output_settings.include_aws_benchmark_metrics,
         )
 
     def run_single_job(self, job: SingleJobExecutorInterface):
@@ -307,6 +308,7 @@ def run_wrapper(
     basedir,
     sourcecache_path,
     runtime_sourcecache_path,
+    include_aws_benchmark_metrics,
 ):
     """
     Wrapper around the run method that handles exceptions and benchmarking.
@@ -482,7 +484,7 @@ def run_wrapper(
                 bench_records,
                 benchmark,
                 benchmark_extended,
-                self.workflow.output_settings.include_aws_benchmark_metrics,
+                include_aws_benchmark_metrics,
             )
         except Exception as ex:
             raise WorkflowError(ex)


### PR DESCRIPTION
## Summary
- pass the include_aws_benchmark_metrics setting into the local executor run wrapper
- ensure benchmark records use the provided flag to avoid NameError exceptions

## Testing
- pytest tests/test_benchmark_aws.py *(fails: ModuleNotFoundError: No module named 'snakemake')*

------
https://chatgpt.com/codex/tasks/task_e_68d50aa682788331b21bc7594cc62cc6